### PR TITLE
feat: use real makeMarshal to handle smallcaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@endo/eventual-send": "^0.17.2",
+    "@endo/far": "^0.2.18",
+    "@endo/marshal": "^0.8.5",
     "@storeon/localstorage": "^1.4.0",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.0.0",
@@ -18,6 +21,7 @@
     "react-dom": "^18.2.0",
     "react-json-view": "^1.21.3",
     "react-query": "^3.39.2",
+    "ses": "^0.18.4",
     "storeon": "^3.1.5"
   },
   "devDependencies": {

--- a/src/installSesLockdown.ts
+++ b/src/installSesLockdown.ts
@@ -1,0 +1,13 @@
+/* global lockdown */
+import 'ses'; // adds lockdown, harden, and Compartment
+import '@endo/eventual-send/shim.js'; // adds support needed by E
+
+const consoleTaming = import.meta.env.DEV ? 'unsafe' : 'safe';
+
+lockdown({
+  errorTaming: 'unsafe',
+  overrideTaming: 'severe',
+  consoleTaming,
+});
+
+Error.stackTraceLimit = Infinity;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import './installSesLockdown';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,6 +249,49 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
+"@endo/eventual-send@^0.17.2":
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/@endo/eventual-send/-/eventual-send-0.17.2.tgz#c8710d557c2f57723be05fe99e941cd893acc5d2"
+  integrity sha512-nux02l2yYXXUeUA2PigOO1K0gbVVMYx3prfYrW/G7Ny6PiDLtOyaeMWwKQwFTgJV2yAkOfvycr4LC1+tm7hu/Q==
+
+"@endo/far@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@endo/far/-/far-0.2.18.tgz#8d8ca8ac1f7c4b57871e55c2c2f06c8e4fcf3839"
+  integrity sha512-NJPz5x11AOsFgxZNSIW4+llQtSUNQtcYCrvxpMwhofti3hncMjhIiUUrMVggw99pdHNmXEBr0gl16H3n/1X0sw==
+  dependencies:
+    "@endo/eventual-send" "^0.17.2"
+    "@endo/pass-style" "^0.1.3"
+
+"@endo/marshal@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@endo/marshal/-/marshal-0.8.5.tgz#c1a10ed4d9b37ee7444d314d8dec9a9a96728d64"
+  integrity sha512-oj2Ag/TlkoMPv8m00fjoa1uWPgDwm5w8nYUU0DPqaCLfTNGRe8a8s7kYDPbv+sQdiQbkZ1RgUQjdyr/O2Mvs+A==
+  dependencies:
+    "@endo/eventual-send" "^0.17.2"
+    "@endo/nat" "^4.1.27"
+    "@endo/pass-style" "^0.1.3"
+    "@endo/promise-kit" "^0.2.56"
+
+"@endo/nat@^4.1.27":
+  version "4.1.27"
+  resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-4.1.27.tgz#8f1a398b39f994b0769070a3fb36d3397bf86794"
+  integrity sha512-mKRdIc4NvrxZ1qPBcYZH6zaj0RsRwADaCcfPNRnGWcHC9dY8DmZDDcgqNdSBFLiEto1RnXeoKAEGxk6hn253Ow==
+
+"@endo/pass-style@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@endo/pass-style/-/pass-style-0.1.3.tgz#951056a2869b04f2aab0928b61a91ae7252ddbe4"
+  integrity sha512-V2FLPBUJXsJYWjMSoZW2IopOuggEX14pm8AHfOVXUceF3uvHbdJj7qwKAuIIOhPApZ/TV+6nWYi86eb393Ic2w==
+  dependencies:
+    "@endo/promise-kit" "^0.2.56"
+    "@fast-check/ava" "^1.1.3"
+
+"@endo/promise-kit@^0.2.56":
+  version "0.2.56"
+  resolved "https://registry.yarnpkg.com/@endo/promise-kit/-/promise-kit-0.2.56.tgz#24ed3cf87af1eec65f4635643b7e67617b909e71"
+  integrity sha512-eKlOg353jJCHwDAwXCajtcAiTTjGkd7oWBXniEEc97gZHK83MeB3pnGT2lhoeq3xzdNw3Xv2DDsowBI194AXeA==
+  dependencies:
+    ses "^0.18.4"
+
 "@esbuild/android-arm@0.15.18":
   version "0.15.18"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.18.tgz#266d40b8fdcf87962df8af05b76219bc786b4f80"
@@ -290,6 +333,13 @@
   version "8.40.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.40.0.tgz#3ba73359e11f5a7bd3e407f70b3528abfae69cec"
   integrity sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==
+
+"@fast-check/ava@^1.1.3":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@fast-check/ava/-/ava-1.1.4.tgz#74b15dad861c08432883f9daa0facffb8c414b46"
+  integrity sha512-lrnFauxiFhhAMN2tZSn2p1GxUvpZPV21c6CRCX47MSz+iiu7og/E/NMHqdN+b3ebNT8jL4Soqs8FxokXWN9moQ==
+  dependencies:
+    fast-check "^3.0.0"
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
@@ -1336,6 +1386,13 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+fast-check@^3.0.0:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-3.8.1.tgz#804db0496e16bd0c4a27d3cba23bb2114b512ba3"
+  integrity sha512-WRll9CUIz6jWKgByFlHT2M/1BY3F7lewKl5BBIz5VHAy7B8y5iklK9rVm922kx+0x1hJqdkffuTs008xfIgytQ==
+  dependencies:
+    pure-rand "^6.0.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -2230,6 +2287,11 @@ pure-color@^1.2.0:
   resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
   integrity sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA==
 
+pure-rand@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.2.tgz#a9c2ddcae9b68d736a8163036f088a2781c8b306"
+  integrity sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -2398,6 +2460,11 @@ semver@^7.3.7:
   integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
   dependencies:
     lru-cache "^6.0.0"
+
+ses@^0.18.4:
+  version "0.18.4"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.18.4.tgz#28781719870262afc6928b7d6d94dc16318dbd86"
+  integrity sha512-Ph0PC38Q7uutHmMM9XPqA7rp/2taiRwW6pIZJwTr4gz90DtrBvy/x7AmNPH2uqNPhKriZpYKvPi1xKWjM9xJuQ==
 
 setimmediate@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Here's a preliminary patch to handle the new smallcaps format (#7). It probably needs some work to make it functional (I don't know how to test it).

* this does the Right Thing(tm) and builds a proper `makeMarshal()` instance to perform the deserialization
  * which will handle both old and new formats
* that adds dependencies on `@endo/marshal`, which in turns requires a SES environment
* I added a copy of `installSesLockdown.ts` from `dapp-econ-gov` (https://github.com/Agoric/dapp-econ-gov/blob/749d17ddd100dea275d8d2e77c271132d93057a6/src/installSesLockdown.ts) which should help created that environment, but it needs to be integrated somehow

The new code uses `unserialize` to convert the raw data into an object tree, similar to what `JSON.parse` does except it handles all the special encodings of our marshalling format (like the Brand objects, and the BigInts that hold the value). Then it does a recursive walk of this tree and converts any objects with both `.brand` and `.value` (which is how we generally represent Amounts) into a string like `${value} ${brand.iface}`. I think that's what the previous implementation was doing, except it could only work with the old (pre-smallcaps) marshalling format.
